### PR TITLE
chore: update vscode extension recommendations

### DIFF
--- a/_template/dotVscode/extensions.json
+++ b/_template/dotVscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "azapi-vscode.azapi",
+    "ams-azuretools.vscode-azureterraform",
     "davidanson.vscode-markdownlint",
     "eamodio.gitlens",
     "fabiospampinato.vscode-open-in-github",
@@ -10,7 +10,7 @@
     "hashicorp.hcl",
     "hashicorp.terraform",
     "jeff-hykin.code-eol",
-    "ms-vscode.azure-account",
+    "ms-azuretools.vscode-azureresourcegroups",
     "run-at-scale.terraform-doc-snippets",
     "streetsidesoftware.code-spell-checker",
     "streetsidesoftware.code-spell-checker-norwegian-bokmal",


### PR DESCRIPTION
## Summary

Updates the recommended VS Code extensions in the project template:

- Replace `azapi-vscode.azapi` (Azure API extension) with `ams-azuretools.vscode-azureterraform` (Azure Terraform extension)
- Replace `ms-vscode.azure-account` (deprecated Azure Account extension) with `ms-azuretools.vscode-azureresourcegroups` (Azure Resources extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)